### PR TITLE
Made error message more verbose, when unable to run the generate command

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -64,7 +64,7 @@ class GenerateCommand(sublime_plugin.WindowCommand):
                     self.window.open_file('%s%s' % (self.PROJECT_PATH, match.group(0)))
                 sublime.status_message("%s generated successfully!" % self.command)
             else:
-                sublime.status_message("Oh snap! generate:%s failed" % self.command)
+                sublime.status_message("Oh snap! generate:%s failed - %s" % (self.command, output))
 
 class ArtisanCommand(sublime_plugin.WindowCommand):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
I had the same issue as in https://github.com/gnarula/sublime-laravelgenerator/issues/17

So I decided to include the output of the process when the generate command fails to run.

![Screen Shot 2013-04-24 at 2 07 13 PM](https://f.cloud.github.com/assets/220535/421559/a63aec36-ad0b-11e2-9d6f-69d883e43b96.PNG)
